### PR TITLE
Add element-set tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A custom integration that surfaces your Bartlett Instruments kiln in Home Assist
 
 - **Live kiln telemetry** — temperature, kiln status, firmware version, lifetime firings count, and zone count.
 - **Firing progress** — estimated time remaining, elapsed firing time, current program segment, set point, and the active program name while a firing is in progress.
+- **Element-set tracking** — record when a new set of heating elements was installed and track how many firings are on the current set, so you know when they're due for replacement.
 - **Multiple kilns per account** — every kiln on your KilnAid account gets its own device and sensors automatically.
 - **Adaptive polling** — polls frequently (default: every 5 minutes) while a kiln is actively firing and backs off (default: every 15 minutes) when idle. Both intervals are configurable in the integration's options.
 - **Reauthentication flow** — if your stored password stops working (e.g. after changing it in the KilnAid app), Home Assistant prompts you to re-enter it without losing your sensors or history.
@@ -34,6 +35,35 @@ meaningful while a firing is in progress; the service reports stale values when
 the kiln is idle.
 
 Sensor names are prefixed with the kiln name so they remain unambiguous when multiple kilns are configured.
+
+## Element-set tracking
+
+Kiln heating elements wear out after a number of firings. Since the kiln's
+**Number of Firings** is a lifetime counter that never resets, the integration
+adds a per-kiln set of element-tracking entities:
+
+| Entity | Type | Purpose |
+| --- | --- | --- |
+| Elements installed | Date *(Configuration)* | The date the current element set was installed. This is the only thing you set — enter it whenever you fit new elements. |
+| Firings on current elements | Sensor | Read-only count of how many firings are on the current set. Counts up as the kiln fires and is graphed in history. |
+
+You only ever set the **Elements installed** date. From it, *Firings on current
+elements* is derived as the lifetime **Number of Firings** today minus what it
+was on that date — read back from Home Assistant's own recorded history of the
+firing counter. After fitting new elements, just set the date and the count
+starts from 0.
+
+This means the date can be entered retroactively: set it to when the elements
+were actually changed and the count is computed from history, no manual
+correction needed. The firing counter is recorded as long-term statistics
+(kept indefinitely), so old dates still work. If you enter a date from *before*
+Home Assistant began recording this kiln, the count shows **unknown** rather
+than a guess.
+
+No separate history of past element sets is stored — Home Assistant keeps it
+natively: the **Elements installed** date logs each replacement, and the
+**Firings on current elements** value is recorded in history so you can graph
+each set's wear over time.
 
 ## Installation (via HACS)
 

--- a/custom_components/kiln_monitor/__init__.py
+++ b/custom_components/kiln_monitor/__init__.py
@@ -21,7 +21,10 @@ from .coordinator import KilnDataCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [
+    Platform.DATE,
+    Platform.SENSOR,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -47,7 +50,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady("No kilns found for this account")
     
     _LOGGER.info("Found %d kiln(s) for account", len(kilns))
-    
+
     # Create a coordinator for each kiln
     coordinators = []
     for kiln_info in kilns:

--- a/custom_components/kiln_monitor/const.py
+++ b/custom_components/kiln_monitor/const.py
@@ -1,6 +1,22 @@
 """Constants for the Kiln Monitor integration."""
+from __future__ import annotations
+
+from typing import Any
 
 DOMAIN = "kiln_monitor"
+
+
+def dig(data: Any, path: list[str]) -> Any:
+    """Walk ``path`` through nested dicts, returning ``None`` if anything is missing.
+
+    Bails out the moment a level isn't a dict or a key is absent so callers never
+    end up coercing ``{}`` to a number.
+    """
+    for key in path:
+        if not isinstance(data, dict) or key not in data:
+            return None
+        data = data[key]
+    return data
 
 # API URLs
 LOGIN_URL = "https://bartinst-user-service-prod.herokuapp.com/login"
@@ -22,6 +38,10 @@ DEFAULT_IDLE_UPDATE_INTERVAL = 15    # minutes, used when the kiln is idle
 
 # kilnStatus strings that should trigger fast polling (case-insensitive)
 ACTIVE_KILN_STATUSES = frozenset({"firing"})
+
+# Path to the kiln's lifetime firing counter in the API response. Shared by the
+# numFirings sensor and the element-tracking logic so the two never drift.
+NUMFIRINGS_DATA_PATH = ["settings", "numFirings"]
 
 # Sensor definitions
 SENSORS = {
@@ -54,7 +74,7 @@ SENSORS = {
         "unit": "firings",
         "device_class": None,
         "state_class": "total_increasing",
-        "data_path": ["settings", "numFirings"],
+        "data_path": NUMFIRINGS_DATA_PATH,
         "value_type": int,
     },
     "numZones": {

--- a/custom_components/kiln_monitor/coordinator.py
+++ b/custom_components/kiln_monitor/coordinator.py
@@ -3,22 +3,29 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import timedelta
+from datetime import date, timedelta
 from typing import Any
 
+from homeassistant.components.recorder import get_instance
+from homeassistant.components.recorder.statistics import statistics_during_period
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .const import (
     ACTIVE_KILN_STATUSES,
     DATA_URL,
+    DOMAIN,
     LOGIN_URL,
+    NUMFIRINGS_DATA_PATH,
     STATUS_URL,
     CONF_EMAIL,
     CONF_PASSWORD,
     DEFAULT_ACTIVE_UPDATE_INTERVAL,
     DEFAULT_IDLE_UPDATE_INTERVAL,
+    dig,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -51,6 +58,10 @@ class KilnDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.email = config_data[CONF_EMAIL]
         self.password = config_data[CONF_PASSWORD]
         self.token: str | None = None
+        # Element-set tracking: the user enters the install date; the baseline
+        # (numFirings at that date) is derived from recorded history.
+        self._installed_at: date | None = None
+        self._element_baseline: int | None = None
 
         if kiln_info:
             self.kiln_id: str | None = kiln_info.get("kiln_id")
@@ -92,6 +103,93 @@ class KilnDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return self._active_interval
         return self._idle_interval
 
+    # ------------------------------------------------------------------
+    # Element-set tracking
+    #
+    # numFirings is the kiln's lifetime firing counter. The user enters the date
+    # the current element set was installed; the baseline (numFirings as of that
+    # date) is read back from Home Assistant's long-term statistics for the
+    # numFirings sensor. "Firings on the current set" is then current - baseline.
+    # The date itself is persisted by the date entity via RestoreEntity.
+    # ------------------------------------------------------------------
+
+    def current_num_firings(self) -> int | None:
+        """Return the kiln's lifetime firing count, or None if not yet known."""
+        value = dig(self.data, NUMFIRINGS_DATA_PATH)
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (ValueError, TypeError):
+            return None
+
+    @property
+    def element_installed_at(self) -> date | None:
+        """Date the current element set was installed, if set."""
+        return self._installed_at
+
+    @property
+    def firings_on_current_elements(self) -> int | None:
+        """Firings accumulated on the current element set, or None if unknown."""
+        lifetime = self.current_num_firings()
+        if lifetime is None or self._element_baseline is None:
+            return None
+        # Guard against a baseline that ended up above the lifetime count.
+        return max(0, lifetime - self._element_baseline)
+
+    async def async_set_installed_date(self, value: date | None) -> None:
+        """Set the element install date and recompute the derived baseline."""
+        self._installed_at = value
+        await self._async_recompute_element_baseline()
+        self.async_update_listeners()
+
+    async def _async_recompute_element_baseline(self) -> None:
+        """Derive the baseline (numFirings at the install date) from history."""
+        if self._installed_at is None:
+            self._element_baseline = None
+            return
+        # Just-changed case: count from now, even before statistics compile.
+        if self._installed_at >= dt_util.now().date():
+            self._element_baseline = self.current_num_firings()
+            return
+        self._element_baseline = await self._async_num_firings_at_install()
+
+    async def _async_num_firings_at_install(self) -> int | None:
+        """Read numFirings at the start of the install date from statistics.
+
+        Returns None when no recorded value covers that date (e.g. the date
+        predates this kiln's recorded history), which surfaces as "unknown".
+        """
+        registry = er.async_get(self.hass)
+        entity_id = registry.async_get_entity_id(
+            "sensor", DOMAIN, f"{self.serial_number}_numFirings"
+        )
+        if entity_id is None:
+            return None
+        day_start = dt_util.start_of_local_day(self._installed_at)
+        window_start = day_start - timedelta(days=30)
+        stats = await get_instance(self.hass).async_add_executor_job(
+            statistics_during_period,
+            self.hass,
+            window_start,
+            day_start,
+            {entity_id},
+            "hour",
+            None,
+            {"state"},
+        )
+        rows = stats.get(entity_id)
+        if not rows:
+            return None
+        # Rows are ascending by start; the last is the value just before install.
+        state = rows[-1].get("state")
+        if state is None:
+            return None
+        try:
+            return int(float(state))
+        except (ValueError, TypeError):
+            return None
+
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
         try:
@@ -126,6 +224,7 @@ class KilnDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self.kiln_name, status, desired_interval,
             )
             self.update_interval = desired_interval
+
         return data
 
     async def _ensure_authenticated(self) -> None:

--- a/custom_components/kiln_monitor/date.py
+++ b/custom_components/kiln_monitor/date.py
@@ -1,0 +1,71 @@
+"""Date platform for Kiln Monitor (element-set install date)."""
+from __future__ import annotations
+
+import logging
+from datetime import date
+
+from homeassistant.components.date import DateEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
+
+from .const import DOMAIN
+from .coordinator import KilnDataCoordinator
+from .entity import KilnBaseEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the date platform."""
+    coordinators: list[KilnDataCoordinator] = hass.data[DOMAIN][config_entry.entry_id]
+    async_add_entities(
+        KilnElementInstalledDate(coordinator) for coordinator in coordinators
+    )
+
+
+class KilnElementInstalledDate(KilnBaseEntity, RestoreEntity, DateEntity):
+    """Install date of the current element set.
+
+    This is the single input for element tracking: enter the date the elements
+    were changed and "Firings on current elements" is derived from the kiln's
+    recorded firing history as of that date. Home Assistant restores the date
+    across restarts via RestoreEntity.
+    """
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "elements_installed"
+    _attr_icon = "mdi:calendar-clock"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator: KilnDataCoordinator) -> None:
+        """Initialize the install-date entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.serial_number}_elements_installed"
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the previously set install date and seed the coordinator."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is None or last_state.state in (None, "unknown", "unavailable"):
+            return
+        try:
+            restored = date.fromisoformat(last_state.state)
+        except ValueError:
+            return
+        await self.coordinator.async_set_installed_date(restored)
+
+    @property
+    def native_value(self) -> date | None:
+        """Return the stored install date."""
+        return self.coordinator.element_installed_at
+
+    async def async_set_value(self, value: date) -> None:
+        """Record the date the current element set was installed."""
+        await self.coordinator.async_set_installed_date(value)

--- a/custom_components/kiln_monitor/entity.py
+++ b/custom_components/kiln_monitor/entity.py
@@ -1,0 +1,32 @@
+"""Shared base entity and helpers for Kiln Monitor."""
+from __future__ import annotations
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, dig
+from .coordinator import KilnDataCoordinator
+
+
+class KilnBaseEntity(CoordinatorEntity[KilnDataCoordinator]):
+    """Base entity binding all Kiln Monitor entities to one kiln device."""
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information about this kiln."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.coordinator.serial_number)},
+            name=self.coordinator.kiln_name or "Kiln",
+            manufacturer="Bartinst",
+            model="Kiln",
+            sw_version=dig(self.coordinator.data, ["settings", "firmwareVersion"]),
+            serial_number=self.coordinator.serial_number,
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data is not None
+        )

--- a/custom_components/kiln_monitor/manifest.json
+++ b/custom_components/kiln_monitor/manifest.json
@@ -5,6 +5,9 @@
     "parsadanov@gmail.com"
   ],
   "config_flow": true,
+  "after_dependencies": [
+    "recorder"
+  ],
   "dependencies": [],
   "documentation": "https://github.com/MrWhoThis/kiln-monitor",
   "integration_type": "hub",

--- a/custom_components/kiln_monitor/sensor.py
+++ b/custom_components/kiln_monitor/sensor.py
@@ -12,12 +12,11 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, SENSORS
+from .const import DOMAIN, SENSORS, dig
 from .coordinator import KilnDataCoordinator
+from .entity import KilnBaseEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,7 +30,7 @@ async def async_setup_entry(
     coordinators: list[KilnDataCoordinator] = hass.data[DOMAIN][config_entry.entry_id]
 
     sensors = []
-    
+
     # Create sensors for each kiln
     for coordinator in coordinators:
         for sensor_key, sensor_config in SENSORS.items():
@@ -42,14 +41,15 @@ async def async_setup_entry(
                     sensor_config=sensor_config,
                 )
             )
-        
-        _LOGGER.info("Created %d sensors for kiln %s", 
-                    len(SENSORS), coordinator.kiln_name)
+        sensors.append(KilnFiringsOnCurrentElementsSensor(coordinator))
+
+        _LOGGER.info("Created %d sensors for kiln %s",
+                    len(SENSORS) + 1, coordinator.kiln_name)
 
     async_add_entities(sensors)
 
 
-class KilnSensor(CoordinatorEntity[KilnDataCoordinator], SensorEntity):
+class KilnSensor(KilnBaseEntity, SensorEntity):
     """Representation of a Kiln sensor."""
 
     def __init__(
@@ -83,59 +83,47 @@ class KilnSensor(CoordinatorEntity[KilnDataCoordinator], SensorEntity):
             self._attr_state_class = SensorStateClass.TOTAL_INCREASING
 
     @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information about this kiln."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.serial_number)},
-            name=self.coordinator.kiln_name or "Kiln",
-            manufacturer="Bartinst",
-            model="Kiln",
-            sw_version=self._get_firmware_version(),
-            serial_number=self.coordinator.serial_number,
-        )
-
-    @property
     def native_value(self) -> Any:
         """Return the state of the sensor."""
-        if not self.coordinator.data:
+        data = dig(self.coordinator.data, self._sensor_config["data_path"])
+        if data is None:
             return None
-            
+
         try:
-            # Navigate through the data path; bail out the moment anything is missing
-            # so we don't end up coercing {} to float/int below.
-            data: Any = self.coordinator.data
-            for key in self._sensor_config["data_path"]:
-                if not isinstance(data, dict):
-                    return None
-                if key not in data:
-                    return None
-                data = data[key]
-
-            if data is None:
-                return None
-
             value_type = self._sensor_config["value_type"]
             if value_type is float:
                 return float(data)
             if value_type is int:
                 return int(data)
             return str(data)
-
-        except (KeyError, ValueError, TypeError) as exc:
-            _LOGGER.error("Failed to parse sensor %s for kiln %s: %s", 
+        except (ValueError, TypeError) as exc:
+            _LOGGER.error("Failed to parse sensor %s for kiln %s: %s",
                          self._sensor_key, self.coordinator.kiln_name, exc)
             return None
 
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return (
-            self.coordinator.last_update_success 
-            and self.coordinator.data is not None
+
+class KilnFiringsOnCurrentElementsSensor(KilnBaseEntity, SensorEntity):
+    """Read-only count of firings accumulated on the current element set.
+
+    Derived as ``current numFirings - numFirings(at install date)``, where the
+    install date comes from the "Elements installed" date entity. Shows
+    "unknown" until an install date is set and recorded history covers it.
+    """
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "firings_on_current_elements"
+    _attr_state_class = SensorStateClass.TOTAL
+    _attr_native_unit_of_measurement = "firings"
+    _attr_icon = "mdi:fire"
+
+    def __init__(self, coordinator: KilnDataCoordinator) -> None:
+        """Initialize the firings-on-current-elements sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = (
+            f"{coordinator.serial_number}_firings_on_current_elements"
         )
 
-    def _get_firmware_version(self) -> str | None:
-        """Get firmware version from data."""
-        if not self.coordinator.data:
-            return None
-        return self.coordinator.data.get("settings", {}).get("firmwareVersion")
+    @property
+    def native_value(self) -> int | None:
+        """Return firings accumulated on the current element set."""
+        return self.coordinator.firings_on_current_elements

--- a/custom_components/kiln_monitor/strings.json
+++ b/custom_components/kiln_monitor/strings.json
@@ -34,6 +34,14 @@
       "reauth_successful": "Reconnected to KilnAid successfully."
     }
   },
+  "entity": {
+    "sensor": {
+      "firings_on_current_elements": { "name": "Firings on current elements" }
+    },
+    "date": {
+      "elements_installed": { "name": "Elements installed" }
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/kiln_monitor/translations/en.json
+++ b/custom_components/kiln_monitor/translations/en.json
@@ -34,6 +34,14 @@
       "reauth_successful": "Reconnected to KilnAid successfully."
     }
   },
+  "entity": {
+    "sensor": {
+      "firings_on_current_elements": { "name": "Firings on current elements" }
+    },
+    "date": {
+      "elements_installed": { "name": "Elements installed" }
+    }
+  },
   "options": {
     "step": {
       "init": {


### PR DESCRIPTION
## Summary

Heating elements wear out after a number of firings, but the kiln's lifetime **Number of Firings** never resets. This adds per-kiln element tracking so you can see how much life is on the current element set — with a single input.

## Entities (per kiln)

| Entity | Type | Purpose |
| --- | --- | --- |
| **Elements installed** | Date *(Configuration)* | The only thing you set — the date the current elements were fitted. |
| **Firings on current elements** | Sensor | Firings accumulated since the install date. |

## How it works

`firings on current elements = current numFirings − numFirings(at install date)`

The historical value is read back from Home Assistant's own **long-term statistics** for the `numFirings` sensor, rather than a baseline we capture and store. Consequences:

- **Retroactive** — set the date to when the elements were actually changed and the count is computed from history; no manual correction.
- **Durable** — long-term statistics are retained indefinitely, so old install dates still resolve.
- **Honest** — a date that predates the kiln's recorded history reads `unknown` instead of guessing.

The install date itself is persisted by the date entity via `RestoreEntity`, so there's no custom storage. `recorder` is declared as an `after_dependency` for the statistics lookup.

## Notes

- New `DATE` platform; shared `KilnBaseEntity` base in `entity.py`.
- Just-installed case (date = today) counts from the current value immediately, before statistics compile.

## Testing

Exercised in the docker HA dev env (HA 2026.5.1, 2 kilns):

- Integration loads cleanly; no errors.
- Replicated the statistics lookup against the live recorder DB: within-history dates resolve a baseline; pre-history dates → `unknown`; today → current count.
- End-to-end via `RestoreEntity`: seeded a past install date and restarted → date restored **and** the sensor recomputed (no exceptions). Setting a kiln's date to today via the UI moved its sensor from `unknown` → `0`.
- `translations/en.json` mirrors `strings.json`.

> Note: the dev account's `numFirings` is frozen (kilns aren't firing), so the derived count lands on `0` for any in-history date — the lookup/compute path is exercised, there's just no firing growth in the test data.